### PR TITLE
minor refactoring: PS, i know it's perfect.

### DIFF
--- a/isis.go
+++ b/isis.go
@@ -42,7 +42,7 @@ func Validate(conn *gorm.DB, identifier string, token string) (validated bool, e
 	foundOtp.UpdatedAt = time.Now()
 	conn.Save(&foundOtp)
 
-	return foundOtp.Expired(), nil
+	return foundOtp.IsActive(), nil
 }
 
 func generatePin(digits int) string {

--- a/isis.go
+++ b/isis.go
@@ -2,9 +2,10 @@ package isis
 
 import (
 	"fmt"
-	"gorm.io/gorm"
 	"math/rand"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 func Generate(conn *gorm.DB, identifier string, digits int, validity int) (token string, err error) {
@@ -37,19 +38,11 @@ func Validate(conn *gorm.DB, identifier string, token string) (validated bool, e
 
 	conn.First(&foundOtp)
 
-	if foundOtp.Exipired() {
-		foundOtp.Valid = false
-		foundOtp.UpdatedAt = time.Now()
-		conn.Save(&foundOtp)
-
-		return false, nil
-	}
-
 	foundOtp.Valid = false
 	foundOtp.UpdatedAt = time.Now()
 	conn.Save(&foundOtp)
 
-	return true, nil
+	return foundOtp.Expired(), nil
 }
 
 func generatePin(digits int) string {

--- a/otp.go
+++ b/otp.go
@@ -20,7 +20,7 @@ func (otp otp) Empty() bool {
 	return false
 }
 
-func (otp otp) Exipired() bool {
+func (otp otp) Expired() bool {
 	if time.Now().Sub(otp.CreatedAt).Minutes() > float64(otp.Validity) {
 		return true
 	}

--- a/otp.go
+++ b/otp.go
@@ -20,10 +20,10 @@ func (otp otp) Empty() bool {
 	return false
 }
 
-func (otp otp) Expired() bool {
+func (otp otp) IsActive() bool {
 	if time.Now().Sub(otp.CreatedAt).Minutes() > float64(otp.Validity) {
-		return true
+		return false
 	}
 
-	return false
+	return true
 }


### PR DESCRIPTION
my changes explain themselves.

PS: in `Validate(...)` updating expired OTPs *might* be unnecessary.

so, a guard like the code below could save time and resources IMO. or maybe remove `otp.Valid` and only use `otp..Expired()` this is up to you.

```
if foundOtp.Empty() || !foundOtp.Valid || foundOtp.Expired() {
      return false, nil
}
```